### PR TITLE
Update jackson-databind dependency to avoid CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10</version>
+      <version>2.9.10.1</version>
     </dependency>
   
     <!-- test -->


### PR DESCRIPTION
This commit updates the jackson-databind dependency to avoid CVE-2019-16942.