### PR TITLE
Tidy dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <license-plugin-version>1.20</license-plugin-version>
+    <slf4j.version>1.7.24</slf4j.version>
   </properties>
 
   <distributionManagement>
@@ -228,7 +229,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.24</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -274,6 +275,12 @@
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
       <version>2.6.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <version>4.3.1</version>
+      <version>4.5.10</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -242,11 +242,6 @@
       <version>4.3.1</version>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.9.10.1</version>

--- a/src/main/java/com/ibm/cics/bundle/deploy/BundleDeployHelper.java
+++ b/src/main/java/com/ibm/cics/bundle/deploy/BundleDeployHelper.java
@@ -34,14 +34,15 @@ import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
-import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -93,8 +94,8 @@ public class BundleDeployHelper {
 		} else {
 			try {
 				httpClient = HttpClients.custom()
-						.setSslcontext(new SSLContextBuilder().loadTrustMaterial(null, (chain, type) -> true).build())
-						.setHostnameVerifier(new AllowAllHostnameVerifier())
+						.setSSLContext(new SSLContextBuilder().loadTrustMaterial(null, TrustAllStrategy.INSTANCE).build())
+						.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
 						.build();
 			} catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
 				throw new BundleDeployException("Error instantiating secure connection", e);

--- a/src/main/java/com/ibm/cics/bundle/deploy/BundleDeployHelper.java
+++ b/src/main/java/com/ibm/cics/bundle/deploy/BundleDeployHelper.java
@@ -28,8 +28,6 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.core.HttpHeaders;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -49,6 +47,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class BundleDeployHelper {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
 
 	public static void deployBundle(URI endpointURL, File bundle, String bunddef, String csdgroup, String cicsplex, String region, String username, String password, boolean allowSelfSignedCertificate) throws BundleDeployException, IOException {
 		MultipartEntityBuilder mpeb = MultipartEntityBuilder.create();
@@ -105,7 +105,7 @@ public class BundleDeployHelper {
 		
 		String credentials = username + ":" + password;
 		String encoding = Base64.getEncoder().encodeToString(credentials.getBytes());
-		httpPost.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoding);
+		httpPost.setHeader(AUTHORIZATION_HEADER, "Basic " + encoding);
 		
 		if (!bundle.exists()) {
 			throw new BundleDeployException("Bundle does not exist: '" + bundle + "'");


### PR DESCRIPTION
Removes the JAX-RS dependency which is not really needed.
Also updates Apache `httpmime` (which pulls in lots of other parts of `httpclient`) to a more modern version.
Also gets slf4j logging showing in the tests by adding `slf4j-simple` under test scope.