### PR TITLE
Enable access to the Bundle-SymbolicName from the OSGi manifest.

### DIFF
--- a/src/main/java/com/ibm/cics/bundle/parts/OsgiBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/OsgiBundlePart.java
@@ -28,9 +28,9 @@ public class OsgiBundlePart extends AbstractJavaBundlePart  {
 	
 	private String osgiVersion;
 
-	public OsgiBundlePart(String symbolicName, String osgiVersion, String jvmServer, File osgiBundle) {
+	public OsgiBundlePart(String name, String symbolicName, String osgiVersion, String jvmServer, File osgiBundle) {
 		super(
-			symbolicName + "_" + osgiVersion,
+			name,
 			BundlePartType.OSGIBUNDLE,
 			symbolicName,
 			jvmServer,
@@ -55,6 +55,17 @@ public class OsgiBundlePart extends AbstractJavaBundlePart  {
 	 */
 	public static String convertMavenVersionToOSGiVersion(String mavenVersion) {
 		return mavenVersion.replaceFirst("-", ".");
+	}
+
+	/**
+	 * Gets the Bundle-SymbolicName header inside the given artifact's manifest.
+	 * @param osgiBundle The OSGi bundle file to find the Bundle-SymbolicName of
+	 * @throws IOException if an I/O error has occurred
+	 * @return The symbolic name or null if the manifest, or the header in the manifest, is not present
+	 */
+	public static String getBundleSymbolicName(File osgiBundle) throws IOException {
+		Manifest manifest = getManifest(osgiBundle);
+		return manifest != null ? getManifestHeader(manifest, "Bundle-SymbolicName") : null;
 	}
 
 	/**

--- a/src/test/java/com/ibm/cics/bundle/deploy/OSGiBundlePartTest.java
+++ b/src/test/java/com/ibm/cics/bundle/deploy/OSGiBundlePartTest.java
@@ -23,7 +23,7 @@ public class OSGiBundlePartTest extends AbstractJavaBundlePartTestCase {
 
 	@Override
 	protected AbstractJavaBundlePart createAbstractJavaBundlePart(File bin) {
-		return new OsgiBundlePart("foo", "1.2.3.456789", "bar", bin);
+		return new OsgiBundlePart("blah", "foo", "1.2.3.456789", "bar", bin);
 	}
 
 	@Override


### PR DESCRIPTION
Symbolic name is typically the fully qualified name (e.g. com.ibm.cics.osgi-bundle) and must match what's in the manifest. Name can be anything, but is typically shorter (e.g. osgi-bundle) so pass them as separate parameters.

Signed-off-by: Tom Foyle <tom.foyle@uk.ibm.com>