### PR TITLE
Correct GPG's pinentry options for Actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,8 @@
           <version>1.6</version>
           <configuration>
             <gpgArguments>
-              <gpgArgument>--batch</gpgArgument>
-              <gpgArgument>--yes</gpgArgument>
-              <gpgArgument>--no-tty</gpgArgument>
+              <arg>--pinentry-mode</arg>
+              <arg>loopback</arg>
             </gpgArguments>
           </configuration>
           <executions>


### PR DESCRIPTION
Corrected this in cics-bundle-maven, but neglected it here.