### PR TITLE
Downgraded some of the plugins from milestones to releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M2</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
@@ -184,7 +184,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>2.22.2</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
maven-deploy-plugin and maven-install-plugin were agreed to be left at 3.0.0-M1 as that was a major milestone/release
