### PR TITLE
fix: update databind dep version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.1</version>
+      <version>2.13.5</version>
     </dependency>
   
     <!-- test -->


### PR DESCRIPTION
A bump is required as the older version looks for a .bom file within its own dependencies that doesn't seem to exist in maven central anymore, and therefore the gradle plugin fails to build. 

Tested building the gradle plugin with the new bumped version in a locally installed common jar, and it reconciles dependencies successfully with the new version.