### PR TITLE
Update actions to later versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -8,10 +8,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: bjhargrave/setup-java@a1600c1f88a7741e2420b0a657f2838cec4f09c5
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'temurin'

--- a/.github/workflows/maven-scheduled-build.yml
+++ b/.github/workflows/maven-scheduled-build.yml
@@ -10,10 +10,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: bjhargrave/setup-java@a1600c1f88a7741e2420b0a657f2838cec4f09c5
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'temurin'


### PR DESCRIPTION
Updates various actions to more recent versions, avoiding deprecation notices and getting off a bugfix `setup-java` action.