### PR TITLE
Updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.ibm.cics</groupId>
   <artifactId>cics-bundle-common</artifactId>
-  <version>1.0.5-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CICS Bundle Common Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <groupId>com.ibm.cics</groupId>
   <artifactId>cics-bundle-common</artifactId>
   <version>1.0.5-SNAPSHOT</version>
   <packaging>jar</packaging>
-  
+
   <name>CICS Bundle Common Parent</name>
 
   <organization>
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <license-plugin-version>2.0.0</license-plugin-version>
-    <slf4j.version>1.7.35</slf4j.version>
+    <slf4j.version>2.0.7</slf4j.version>
   </properties>
 
   <distributionManagement>
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -56,7 +56,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.10.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.5.3.0</version>
+        <version>4.7.3.4</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>
@@ -127,7 +127,7 @@
           <executions>
             <execution>
               <goals>
-                 <goal>jar-no-fork</goal>
+                <goal>jar-no-fork</goal>
               </goals>
             </execution>
           </executions>
@@ -135,7 +135,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.5.0</version>
           <executions>
             <execution>
               <goals>
@@ -150,7 +150,7 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.8</version>
+          <version>1.6.13</version>
           <extensions>true</extensions>
           <configuration>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
@@ -160,31 +160,31 @@
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>3.0.0-M1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
           <version>3.2.0</version>
         </plugin>
         <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.10.0</version>
+          <version>3.12.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.0.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -219,7 +219,7 @@
         </pluginManagement>
       </build>
     </profile>
-    
+
     <profile>
       <id>sign</id>
       <build>
@@ -231,7 +231,7 @@
         </plugins>
       </build>
     </profile>
-    
+
     <profile>
       <id>attach-extras</id>
       <activation>
@@ -253,7 +253,7 @@
         </plugins>
       </build>
     </profile>
-    
+
     <profile>
       <id>add-licences</id>
       <build>
@@ -278,12 +278,12 @@
       </build>
     </profile>
   </profiles>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.22</version>
+      <version>1.18.26</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -299,19 +299,19 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <version>4.5.13</version>
+      <version>4.5.14</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.5</version>
+      <version>2.15.0</version>
     </dependency>
-  
+
     <!-- test -->
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <version>2.32.0</version>
+      <artifactId>wiremock-jre8-standalone</artifactId>
+      <version>2.35.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -323,13 +323,13 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/ibm/cics/bundle/parts/BundlePublisher.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/BundlePublisher.java
@@ -63,19 +63,16 @@ public class BundlePublisher {
 	private final int major;
 	private final int minor;
 	private final int micro;
-	private final long release;
-	
 	private Consumer<Path> listener = f -> {};
 	private Map<Path, BundleResource> bundleResources = new HashMap<>();
 	private List<Define> defines = new ArrayList<>();
 
-	public BundlePublisher(Path bundleRoot, String bundleId, int major, int minor, int micro, long release) {
+	public BundlePublisher(Path bundleRoot, String bundleId, int major, int minor, int micro) {
 		this.bundleRoot = bundleRoot;
 		this.bundleId = bundleId;
 		this.major = major;
 		this.minor = minor;
 		this.micro = micro;
-		this.release = release;
 	}
 	
 	public void addStaticResource(Path path, BundleResourceContentSupplier content) throws PublishException {
@@ -157,8 +154,7 @@ public class BundlePublisher {
 			bundleId,
 			major,
 			minor,
-			micro,
-			release
+			micro
 		);
 		
 		for (Map.Entry<Path, BundleResource> bundleResourceE : bundleResources.entrySet()) {
@@ -200,7 +196,7 @@ public class BundlePublisher {
 		}
 	}
 	
-	private void writeManifest(List<Define> defines, String id, int major, int minor, int micro, long release) throws PublishException {
+	private void writeManifest(List<Define> defines, String id, int major, int minor, int micro) throws PublishException {
 		Document d = DOCUMENT_BUILDER.newDocument();
 		Element root = d.createElementNS(BundlePartType.NS, "manifest");
 		root.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns", BundlePartType.NS);
@@ -209,7 +205,7 @@ public class BundlePublisher {
 		root.setAttribute("bundleMajorVer", String.valueOf(major));
 		root.setAttribute("bundleMinorVer", String.valueOf(minor));
 		root.setAttribute("bundleMicroVer", String.valueOf(micro));
-		root.setAttribute("bundleRelease", String.valueOf(release));
+		root.setAttribute("bundleRelease", "0");
 		root.setAttribute("bundleVersion", "1");
 		
 		d.appendChild(root);

--- a/src/main/java/com/ibm/cics/bundle/parts/BundlePublisher.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/BundlePublisher.java
@@ -63,13 +63,13 @@ public class BundlePublisher {
 	private final int major;
 	private final int minor;
 	private final int micro;
-	private final int release;
+	private final long release;
 	
 	private Consumer<Path> listener = f -> {};
 	private Map<Path, BundleResource> bundleResources = new HashMap<>();
 	private List<Define> defines = new ArrayList<>();
 
-	public BundlePublisher(Path bundleRoot, String bundleId, int major, int minor, int micro, int release) {
+	public BundlePublisher(Path bundleRoot, String bundleId, int major, int minor, int micro, long release) {
 		this.bundleRoot = bundleRoot;
 		this.bundleId = bundleId;
 		this.major = major;
@@ -200,7 +200,7 @@ public class BundlePublisher {
 		}
 	}
 	
-	private void writeManifest(List<Define> defines, String id, int major, int minor, int micro, int release) throws PublishException {
+	private void writeManifest(List<Define> defines, String id, int major, int minor, int micro, long release) throws PublishException {
 		Document d = DOCUMENT_BUILDER.newDocument();
 		Element root = d.createElementNS(BundlePartType.NS, "manifest");
 		root.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns", BundlePartType.NS);

--- a/src/test/java/com/ibm/cics/bundle/deploy/BundlePublisherTest.java
+++ b/src/test/java/com/ibm/cics/bundle/deploy/BundlePublisherTest.java
@@ -53,7 +53,7 @@ public class BundlePublisherTest {
 
 	@Test
 	public void publish() throws Exception {
-		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3, 4);
+		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3);
 		bundlePublisher.addResource(new EarBundlePart("bar", "banana", ear));
 		
 		bundlePublisher.publishResources();
@@ -78,7 +78,7 @@ public class BundlePublisherTest {
 			cicsXml,
 			isIdenticalTo(
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-				"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"1\" bundleMicroVer=\"3\" bundleMinorVer=\"2\" bundleRelease=\"4\" bundleVersion=\"1\" id=\"foo\">\n" + 
+				"<manifest xmlns=\"http://www.ibm.com/xmlns/prod/cics/bundle\" bundleMajorVer=\"1\" bundleMicroVer=\"3\" bundleMinorVer=\"2\" bundleRelease=\"0\" bundleVersion=\"1\" id=\"foo\">\n" +
 				"  <meta_directives>\n" + 
 				"    <timestamp>2019-08-28T08:26:05.076Z</timestamp>\n" + 
 				"  </meta_directives>\n" + 


### PR DESCRIPTION
Updates dependencies. Maven plugin has a new updated version of build-helper, and that has changed a signature so VersionInformation objects now return a long instead of int.

This PR changes some of the types, and in gradle to conform we will cast the value from an int to a long which should always work. The alternative was just changing the maven code to cast from long to int, but theres a chance this could fail, so doing it this way round is safer.