### PR TITLE
Add appConfigfile and addCICSAllAuth properties to WAR and EAR bundleparts

### DIFF
--- a/src/main/java/com/ibm/cics/bundle/parts/AbstractJavaBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/AbstractJavaBundlePart.java
@@ -28,11 +28,25 @@ import javax.xml.transform.TransformerException;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-public abstract class AbstractJavaBundlePart extends BundlePartResource {
 
+/**
+ * Defines a CICS bundle part that deploys a Java application.
+ */
+public abstract class AbstractJavaBundlePart extends BundlePartResource {
+	/** The JVM server this CICS bundle part should be deployed to */
 	private final String jvmServer;
+
+	/** The file containing the Java application binary */
 	private final File bin;
+
+	/** The extension of the Java application file (e.g. 'jar') */
 	private final String binExtension;
+
+	/**
+	 * The symbolic name of the Java application. For OSGi bundles this would be the
+	 * Bundle-SymbolicName, otherwise it is the file name of the Java application
+	 * without the extension.
+	 */
 	private final String symbolicName;
 
 	public AbstractJavaBundlePart(
@@ -43,7 +57,8 @@ public abstract class AbstractJavaBundlePart extends BundlePartResource {
 			File bin,
 			String binExtension) {
 		super(name, type);
-		if (jvmServer == null || "".equals(jvmServer)) throw new IllegalStateException("JVM server was not supplied");
+		if (jvmServer == null || "".equals(jvmServer))
+			throw new IllegalStateException("JVM server was not supplied");
 		this.jvmServer = jvmServer;
 		this.symbolicName = symbolicName;
 		this.bin = bin;
@@ -53,7 +68,7 @@ public abstract class AbstractJavaBundlePart extends BundlePartResource {
 	@Override
 	public InputStream getContent() throws IOException {
 		Document bundlePart = BundlePublisher.createDocument();
-		
+
 		Element root = bundlePart.createElement(getType().getBundlePartExtension());
 		bundlePart.appendChild(root);
 
@@ -61,9 +76,9 @@ public abstract class AbstractJavaBundlePart extends BundlePartResource {
 		root.setAttribute("jvmserver", jvmServer);
 
 		addAdditionalNodes(root);
-		
+
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		
+
 		try {
 			BundlePublisher.writeDocument(bundlePart, outputStream);
 			return new ByteArrayInputStream(outputStream.toByteArray());
@@ -71,14 +86,21 @@ public abstract class AbstractJavaBundlePart extends BundlePartResource {
 			throw new IOException(e);
 		}
 	}
-	
+
 	@Override
 	public List<BundleResource> getDynamicResources() {
-		return Collections.singletonList(new StaticBundleResource(Paths.get(getName() + "." + binExtension), () -> new FileInputStream(bin)));
+		return Collections.singletonList(
+				new StaticBundleResource(Paths.get(getName() + "." + binExtension), () -> new FileInputStream(bin)));
 	}
-	
+
+	/**
+	 * Add any additional nodes (e.g. attributes, child elements) to the CICS bundle
+	 * part descriptor.
+	 * 
+	 * @param rootElement The root element of the CICS bundle part descriptor.
+	 */
 	protected void addAdditionalNodes(Element rootElement) {
-		//no-op
+		// no-op
 	}
-	
+
 }

--- a/src/main/java/com/ibm/cics/bundle/parts/AbstractLibertyApplicationBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/AbstractLibertyApplicationBundlePart.java
@@ -1,0 +1,95 @@
+package com.ibm.cics.bundle.parts;
+
+/*-
+ * #%L
+ * CICS Bundle Common Parent
+ * %%
+ * Copyright (C) 2026 IBM Corp.
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.w3c.dom.Element;
+
+/**
+ * Defines a CICS Java bundle part that is deployed to a Liberty server.
+ */
+public abstract class AbstractLibertyApplicationBundlePart extends AbstractJavaBundlePart {
+    /**
+     * Controls whether CICS adds the 'cicsAllAuthenticated' security role to the
+     * application.
+     */
+    private final boolean addCicsAllAuthenticatedRole;
+
+    /**
+     * The file containing application configuration to apply to the application.
+     */
+    private final File libertyAppConfigFile;
+
+    /**
+     * @param name
+     * @param type                        The type of the bundle part.
+     * @param symbolicName                The symbolic name of the bundle part.
+     * @param jvmServer                   The JVM server the bundle part is deployed
+     *                                    to.
+     * @param addCicsAllAuthenticatedRole Controls whether CICS adds the
+     *                                    'cicsAllAuthenticated' security role to
+     *                                    the application.
+     * @param libertyAppConfigFile        The file containing application
+     *                                    configuration to apply to the application.
+     * @param bin                         The file to deploy in the bundle part.
+     * @param binExtension                The extension of the file.
+     */
+    public AbstractLibertyApplicationBundlePart(String name, BundlePartType type, String symbolicName, String jvmServer,
+            boolean addCicsAllAuthenticatedRole, File libertyAppConfigFile, File bin,
+            String binExtension) {
+        super(name, type, symbolicName, jvmServer, bin, binExtension);
+        this.addCicsAllAuthenticatedRole = addCicsAllAuthenticatedRole;
+        this.libertyAppConfigFile = libertyAppConfigFile;
+    }
+
+    @Override
+    protected void addAdditionalNodes(Element rootElement) {
+        // Add the appConfigFile element, if set.
+        if (this.libertyAppConfigFile != null) {
+            rootElement.setAttribute("appConfigFile", libertyAppConfigFile.getName());
+        }
+
+        // Add the addCICSAllAuth element, if the role shouldn't be added.
+        if (!this.addCicsAllAuthenticatedRole) {
+            rootElement.setAttribute("addCICSAllAuth", Boolean.toString(this.addCicsAllAuthenticatedRole));
+        }
+    }
+
+    @Override
+    public List<BundleResource> getDynamicResources() {
+        List<BundleResource> dynamicResources = super.getDynamicResources();
+
+        if (this.libertyAppConfigFile == null) {
+            // Nothing else to add, so we can return early
+            return dynamicResources;
+        }
+
+        // dynamicResource currently returns an unmodifiable list, so we need to create
+        // a new list with the contents of the super one to be able to add to them.
+        List<BundleResource> resources = new ArrayList<>(dynamicResources);
+
+        BundleResource configFileResource = new StaticBundleResource(Paths.get(this.libertyAppConfigFile.getName()),
+                () -> new FileInputStream(this.libertyAppConfigFile));
+        resources.add(configFileResource);
+
+        return resources;
+    }
+
+}

--- a/src/main/java/com/ibm/cics/bundle/parts/AbstractLibertyApplicationBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/AbstractLibertyApplicationBundlePart.java
@@ -38,7 +38,7 @@ public abstract class AbstractLibertyApplicationBundlePart extends AbstractJavaB
     private final File libertyAppConfigFile;
 
     /**
-     * @param name
+     * @param name                        The name of the bundle part.
      * @param type                        The type of the bundle part.
      * @param symbolicName                The symbolic name of the bundle part.
      * @param jvmServer                   The JVM server the bundle part is deployed

--- a/src/main/java/com/ibm/cics/bundle/parts/BundleResource.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/BundleResource.java
@@ -17,10 +17,19 @@ package com.ibm.cics.bundle.parts;
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Defines a resource within a CICS bundle.
+ */
 public interface BundleResource extends BundleResourceContentSupplier {
-	
+	/**
+	 * @return The path to the CICS bundle part descriptor.
+	 */
 	public Path getPath();
-	
+
+	/**
+	 * @return A list of the resource in this CICS bundle part that are pointed to
+	 *         by the bundle part descriptor.
+	 */
 	public List<BundleResource> getDynamicResources();
-	
+
 }

--- a/src/main/java/com/ibm/cics/bundle/parts/BundleResourceContentSupplier.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/BundleResourceContentSupplier.java
@@ -25,7 +25,7 @@ public interface BundleResourceContentSupplier {
 
 	/**
 	 * @return The contents of the resource in a stream.
-	 * @throws IOException
+	 * @throws IOException If the content cannot be read.
 	 */
 	public InputStream getContent() throws IOException;
 	

--- a/src/main/java/com/ibm/cics/bundle/parts/BundleResourceContentSupplier.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/BundleResourceContentSupplier.java
@@ -17,9 +17,16 @@ package com.ibm.cics.bundle.parts;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Supplies the content of a CICS bundle resource.
+ */
 @FunctionalInterface
 public interface BundleResourceContentSupplier {
 
+	/**
+	 * @return The contents of the resource in a stream.
+	 * @throws IOException
+	 */
 	public InputStream getContent() throws IOException;
 	
 }

--- a/src/main/java/com/ibm/cics/bundle/parts/EarBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/EarBundlePart.java
@@ -16,17 +16,53 @@ package com.ibm.cics.bundle.parts;
 
 import java.io.File;
 
-public class EarBundlePart extends AbstractJavaBundlePart {
-	
+/**
+ * Definition of an enterprise application CICS bundle part.
+ * <p>
+ * This is defined by the <code>earbundle</code> XML element, with the
+ * <code>http://www.ibm.com/xmlns/prod/cics/bundle/EARBUNDLE</code> schema.
+ */
+public class EarBundlePart extends AbstractLibertyApplicationBundlePart {
+
+	/**
+	 * @param symbolicName The symbolic name of the application file.
+	 * @param jvmServer    The JVM server the enterprise application is deployed to.
+	 * @param earFile      The enterprise application file this CICS bundle part
+	 *                     deploys.
+	 */
 	public EarBundlePart(String symbolicName, String jvmServer, File earFile) {
-		super(
-			symbolicName,
-			BundlePartType.EARBUNDLE,
-			symbolicName,
-			jvmServer,
-			earFile,
-			"ear"
-		);
+		this(
+				symbolicName,
+				jvmServer,
+				true,
+				null,
+				earFile);
 	}
-	
+
+	/**
+	 * @param symbolicName                The symbolic name of the application file.
+	 * @param jvmServer                   The JVM server the enterprise application
+	 *                                    is deployed to.
+	 * @param addCicsAllAuthenticatedRole Controls whether CICS adds the
+	 *                                    'cicsAllAuthenticated' security role to
+	 *                                    the enterprise application.
+	 * @param libertyAppConfigFile        The file containing application
+	 *                                    configuration to apply to the enterprise
+	 *                                    application.
+	 * @param earFile                     The enterprise application file this CICS
+	 *                                    bundle part deploys.
+	 */
+	public EarBundlePart(String symbolicName, String jvmServer, boolean addCicsAllAuthenticatedRole,
+			File libertyAppConfigFile, File earFile) {
+		super(
+				symbolicName,
+				BundlePartType.EARBUNDLE,
+				symbolicName,
+				jvmServer,
+				addCicsAllAuthenticatedRole,
+				libertyAppConfigFile,
+				earFile,
+				"ear");
+	}
+
 }

--- a/src/main/java/com/ibm/cics/bundle/parts/EbaBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/EbaBundlePart.java
@@ -16,17 +16,22 @@ package com.ibm.cics.bundle.parts;
 
 import java.io.File;
 
-public class EbaBundlePart extends AbstractJavaBundlePart  {
-	
-	public EbaBundlePart(String symbolicName, String jvmServer, File warFile) {
+/**
+ * Definition of an enterprise bundle CICS bundle part.
+ * <p>
+ * This is defined by the <code>ebabundle</code> XML element, with the
+ * <code>http://www.ibm.com/xmlns/prod/cics/bundle/EBABUNDLE</code> schema.
+ */
+public class EbaBundlePart extends AbstractJavaBundlePart {
+
+	public EbaBundlePart(String symbolicName, String jvmServer, File ebaFile) {
 		super(
-			symbolicName,
-			BundlePartType.EBABUNDLE,
-			symbolicName,
-			jvmServer,
-			warFile,
-			"eba"
-		);
+				symbolicName,
+				BundlePartType.EBABUNDLE,
+				symbolicName,
+				jvmServer,
+				ebaFile,
+				"eba");
 	}
 
 }

--- a/src/main/java/com/ibm/cics/bundle/parts/OsgiBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/OsgiBundlePart.java
@@ -24,6 +24,13 @@ import java.util.jar.Manifest;
 
 import org.w3c.dom.Element;
 
+
+/**
+ * Definition of an OSGi bundle CICS bundle part.
+ * <p>
+ * This is defined by the <code>osgibundle</code> XML element, with the
+ * <code>http://www.ibm.com/xmlns/prod/cics/bundle/OSGIBUNDLE</code> schema.
+ */
 public class OsgiBundlePart extends AbstractJavaBundlePart  {
 	
 	private String osgiVersion;

--- a/src/main/java/com/ibm/cics/bundle/parts/WarBundlePart.java
+++ b/src/main/java/com/ibm/cics/bundle/parts/WarBundlePart.java
@@ -16,17 +16,53 @@ package com.ibm.cics.bundle.parts;
 
 import java.io.File;
 
-public class WarBundlePart extends AbstractJavaBundlePart  {
-	
+/**
+ * Definition of an web application CICS bundle part.
+ * <p>
+ * This is defined by the <code>warbundle</code> XML element, with the
+ * <code>http://www.ibm.com/xmlns/prod/cics/bundle/WARBUNDLE</code> schema.
+ */
+public class WarBundlePart extends AbstractLibertyApplicationBundlePart {
+
+	/**
+	 * @param symbolicName The symbolic name of the application file.
+	 * @param jvmServer    The JVM server the enterprise application is deployed to.
+	 * @param warFile      The web application file this CICS bundle part
+	 *                     deploys.
+	 */
 	public WarBundlePart(String symbolicName, String jvmServer, File warFile) {
+		this(
+				symbolicName,
+				jvmServer,
+				true,
+				null,
+				warFile);
+	}
+
+	/**
+	 * @param symbolicName                The symbolic name of the application file.
+	 * @param jvmServer                   The JVM server the enterprise application
+	 *                                    is deployed to.
+	 * @param addCicsAllAuthenticatedRole Controls whether CICS adds the
+	 *                                    'cicsAllAuthenticated' security role to
+	 *                                    the web application.
+	 * @param libertyAppConfigFile        The file containing application
+	 *                                    configuration to apply to the web
+	 *                                    application.
+	 * @param warFile                     The web application file this CICS bundle
+	 *                                    part deploys.
+	 */
+	public WarBundlePart(String symbolicName, String jvmServer, boolean addCicsAllAuthenticatedRole,
+			File libertyAppConfigFile, File warFile) {
 		super(
-			symbolicName,
-			BundlePartType.WARBUNDLE,
-			symbolicName,
-			jvmServer,
-			warFile,
-			"war"
-		);
+				symbolicName,
+				BundlePartType.WARBUNDLE,
+				symbolicName,
+				jvmServer,
+				addCicsAllAuthenticatedRole,
+				libertyAppConfigFile,
+				warFile,
+				"war");
 	}
 
 }

--- a/src/test/java/com/ibm/cics/bundle/deploy/AbstractJavaBundlePartTestCase.java
+++ b/src/test/java/com/ibm/cics/bundle/deploy/AbstractJavaBundlePartTestCase.java
@@ -1,22 +1,22 @@
 package com.ibm.cics.bundle.deploy;
 
 /*-
- * #%L
- * CICS Bundle Common Parent
- * %%
- * Copyright (C) 2019, 2023 IBM Corp.
- * %%
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
- * #L%
- */
+* #%L
+* CICS Bundle Common Parent
+* %%
+* Copyright (C) 2019, 2023 IBM Corp.
+* %%
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+* 
+* SPDX-License-Identifier: EPL-2.0
+* #L%
+*/
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -126,3 +126,4 @@ public abstract class AbstractJavaBundlePartTestCase {
 	}
 
 }
+ 

--- a/src/test/java/com/ibm/cics/bundle/deploy/BundleDeployHelperTest.java
+++ b/src/test/java/com/ibm/cics/bundle/deploy/BundleDeployHelperTest.java
@@ -18,6 +18,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -27,228 +29,217 @@ import javax.net.ssl.SSLException;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 public class BundleDeployHelperTest {
-	
+
 	@Rule
-	public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicHttpsPort());
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
+	public WireMockRule wireMockRule = new WireMockRule(
+			WireMockConfiguration.options().dynamicPort().dynamicHttpsPort());
+
 	private static String bundleFilePath = "src/test/resources/test-app-bundle-0.0.1-SNAPSHOT.zip";
 
-	
 	@Test
 	public void testBundleDeployHelper_response200() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Some content")
-			)
-		);
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Some content")));
 
 		File bundleArchive = new File(bundleFilePath);
 
-		BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup", "cicsplex", "region", "username", "password".toCharArray(), true);
+		BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup",
+				"cicsplex", "region", "username", "password".toCharArray(), true);
 	}
-	
+
 	@Test
 	public void testBundleDeployHelper_selfSignedNotValid() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Some content")
-			)
-		);
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Some content")));
 
 		File bundleArchive = new File(bundleFilePath);
 
 		try {
-			BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup", "cicsplex", "region", "username", "password".toCharArray(), false);
+			BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup",
+					"cicsplex", "region", "username", "password".toCharArray(), false);
 			fail("Expected SSLException because self signed certificates are not allowed");
 		} catch (SSLException e) {
 			// pass
 		}
 	}
-	
+
 	@Test
 	public void testBundleDeployHelper_invalidFile() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Some content")
-			)
-		);
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Some content")));
 
 		File bundleArchive = new File("invalid path");
-		
-		expectedException.expect(BundleDeployException.class);
-		expectedException.expectMessage("Bundle does not exist: 'invalid path'");
-		
-		BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup", "cicsplex", "region", "username", "password".toCharArray(), true);
+
+		BundleDeployException e = assertThrows(BundleDeployException.class, () -> {
+			BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup",
+					"cicsplex", "region", "username", "password".toCharArray(), true);
+		});
+
+		assertEquals("Bundle does not exist: 'invalid path'", e.getMessage());
 	}
-	
+
 	@Test
 	public void testBundleDeployHelper_invalidBundle() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(400)
-				.withHeader("Content-Type", "application/json")
-				.withBody("{\"message\":\"Some of the supplied parameters were invalid\",\"requestErrors\":{\"bundle\":\"Derived bundledir \\\"" + bundleFilePath + "\\\" didn't match the target BUNDDEF's bundle dir \\\"" + bundleFilePath + "\\\"\"}}")
-			)
-		);
+				.willReturn(aResponse()
+						.withStatus(400)
+						.withHeader("Content-Type", "application/json")
+						.withBody(
+								"{\"message\":\"Some of the supplied parameters were invalid\",\"requestErrors\":{\"bundle\":\"Derived bundledir \\\""
+										+ bundleFilePath + "\\\" didn't match the target BUNDDEF's bundle dir \\\""
+										+ bundleFilePath + "\\\"\"}}")));
 
 		File bundleArchive = new File(bundleFilePath);
-		
-		expectedException.expect(BundleDeployException.class);
-		expectedException.expectMessage("Some of the supplied parameters were invalid:\n - bundle: Derived bundledir \"" + bundleFilePath + "\" didn't match the target BUNDDEF's bundle dir \"" + bundleFilePath + "\"\n");;
-		
-		BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup", "cicsplex", "region", "username", "password".toCharArray(), true);
+
+		BundleDeployException e = assertThrows(BundleDeployException.class, () -> {
+			BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup",
+					"cicsplex", "region", "username", "password".toCharArray(), true);
+
+		});
+		assertEquals(
+				"Some of the supplied parameters were invalid:\n - bundle: Derived bundledir \"" + bundleFilePath
+						+ "\" didn't match the target BUNDDEF's bundle dir \"" + bundleFilePath + "\"\n",
+				e.getMessage());
+
 	}
-	
+
 	@Test
 	public void testBundleDeployHelper_unauthenticated401() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(401)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Http response: HTTP/1.1 401 Unauthorized")
-			)
-		);
+				.willReturn(aResponse()
+						.withStatus(401)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Http response: HTTP/1.1 401 Unauthorized")));
 
 		File bundleArchive = new File(bundleFilePath);
-		
-		expectedException.expect(BundleDeployException.class);
-		expectedException.expectMessage("Http response: HTTP/1.1 401 Unauthorized");
 
-		BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup", "cicsplex", "region", "username", "password".toCharArray(), true);
+		BundleDeployException e = assertThrows(BundleDeployException.class, () -> {
+			BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup",
+					"cicsplex", "region", "username", "password".toCharArray(), true);
+		});
+		assertEquals("Http response: HTTP/1.1 401 Unauthorized", e.getMessage());
+
 	}
-	
+
 	@Test
 	public void testBundleDeployHelper_unauthenticated401_noContentType() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(401)
-				.withBody("Http response: HTTP/1.1 401 Unauthorized")
-			)
-		);
+				.willReturn(aResponse()
+						.withStatus(401)
+						.withBody("Http response: HTTP/1.1 401 Unauthorized")));
 
 		File bundleArchive = new File(bundleFilePath);
-		
-		expectedException.expect(BundleDeployException.class);
-		expectedException.expectMessage("Http response: 401");
 
-		BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup", "cicsplex", "region", "username", "password".toCharArray(), true);
+		BundleDeployException e = assertThrows(BundleDeployException.class, () -> {
+			BundleDeployHelper.deployBundle(new URI(wireMockRule.baseUrl()), bundleArchive, "bundle", "csdgroup",
+					"cicsplex", "region", "username", "password".toCharArray(), true);
+		});
+		assertEquals("Http response: 401", e.getMessage());
+
 	}
-	
+
 	@Test
 	public void noPath() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Some content")
-			)
-		);
-		
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Some content")));
+
 		File bundleArchive = new File(bundleFilePath);
-		
+
 		BundleDeployHelper.deployBundle(
-			new URI(wireMockRule.baseUrl()),
-			bundleArchive,
-			"bundle",
-			"csdgroup",
-			"cicsplex",
-			"region",
-			"username",
-			"password".toCharArray(),
-			true
-		);
+				new URI(wireMockRule.baseUrl()),
+				bundleArchive,
+				"bundle",
+				"csdgroup",
+				"cicsplex",
+				"region",
+				"username",
+				"password".toCharArray(),
+				true);
 	}
-	
+
 	@Test
 	public void noPathSlash() throws Exception {
 		stubFor(post(urlEqualTo("/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Some content")
-			)
-		);
-		
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Some content")));
+
 		File bundleArchive = new File(bundleFilePath);
-		
+
 		URI endpointURL = new URI(wireMockRule.baseUrl() + "/");
 		BundleDeployHelper.deployBundle(
-			endpointURL,
-			bundleArchive,
-			"bundle",
-			"csdgroup",
-			"cicsplex",
-			"region",
-			"username",
-			"password".toCharArray(),
-			true
-		);
+				endpointURL,
+				bundleArchive,
+				"bundle",
+				"csdgroup",
+				"cicsplex",
+				"region",
+				"username",
+				"password".toCharArray(),
+				true);
 	}
-	
+
 	@Test
 	public void pathNoSlash() throws Exception {
 		stubFor(post(urlEqualTo("/foo/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Some content")
-			)
-		);
-		
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Some content")));
+
 		File bundleArchive = new File(bundleFilePath);
-		
+
 		URI endpointURL = new URI(wireMockRule.baseUrl() + "/foo");
 		BundleDeployHelper.deployBundle(
-			endpointURL,
-			bundleArchive,
-			"bundle",
-			"csdgroup",
-			"cicsplex",
-			"region",
-			"username",
-			"password".toCharArray(),
-			true
-		);
+				endpointURL,
+				bundleArchive,
+				"bundle",
+				"csdgroup",
+				"cicsplex",
+				"region",
+				"username",
+				"password".toCharArray(),
+				true);
 	}
-	
+
 	@Test
 	public void pathEndsWithSlash() throws Exception {
 		stubFor(post(urlEqualTo("/foo/managedcicsbundles"))
-			.willReturn(aResponse()
-				.withStatus(200)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Some content")
-			)
-		);
-		
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "text/plain")
+						.withBody("Some content")));
+
 		File bundleArchive = new File(bundleFilePath);
-		
+
 		URI endpointURL = new URI(wireMockRule.baseUrl() + "/foo/");
 		BundleDeployHelper.deployBundle(
-			endpointURL,
-			bundleArchive,
-			"bundle",
-			"csdgroup",
-			"cicsplex",
-			"region",
-			"username",
-			"password".toCharArray(),
-			true
-		);
+				endpointURL,
+				bundleArchive,
+				"bundle",
+				"csdgroup",
+				"cicsplex",
+				"region",
+				"username",
+				"password".toCharArray(),
+				true);
 	}
 }

--- a/src/test/java/com/ibm/cics/bundle/deploy/BundlePublisherTest.java
+++ b/src/test/java/com/ibm/cics/bundle/deploy/BundlePublisherTest.java
@@ -13,9 +13,8 @@ package com.ibm.cics.bundle.deploy;
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
-
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 
 import java.io.File;
@@ -35,6 +34,7 @@ import org.junit.rules.TemporaryFolder;
 
 import com.ibm.cics.bundle.parts.BundlePublisher;
 import com.ibm.cics.bundle.parts.EarBundlePart;
+import com.ibm.cics.bundle.parts.WarBundlePart;
 
 public class BundlePublisherTest {
 	
@@ -70,7 +70,7 @@ public class BundlePublisherTest {
 			.map(Path::toString)
 			.collect(Collectors.toList());
 		
-		assertThat(paths, contains("", "META-INF", "META-INF/cics.xml", "bar.ear", "bar.earbundle"));
+		assertThat(paths, containsInAnyOrder("", "META-INF", "META-INF" + File.separator + "cics.xml", "bar.ear", "bar.earbundle"));
 		
 		String cicsXml = readBundleFile(root, "META-INF/cics.xml");
 		
@@ -100,6 +100,147 @@ public class BundlePublisherTest {
 			isIdenticalTo(
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
 				"<earbundle jvmserver=\"banana\" symbolicname=\"bar\"/>"
+			)
+		);
+	}
+
+	@Test
+	public void publishEarWithAppConfigFile() throws Exception {
+		File appConfigFile = tf.newFile("ear-app-config.xml");
+		FileUtils.write(appConfigFile, "<server></server>", StandardCharsets.UTF_8);
+		
+		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3);
+		bundlePublisher.addResource(new EarBundlePart("bar", "banana", true, appConfigFile, ear));
+		
+		bundlePublisher.publishResources();
+		bundlePublisher.publishDynamicResources();
+		
+		List<String> paths = Files
+			.walk(bundleRoot)
+			.sorted()
+			.map(bundleRoot::relativize)
+			.map(Path::toString)
+			.collect(Collectors.toList());
+		
+		assertThat(paths, containsInAnyOrder("", "META-INF", "META-INF" + File.separator + "cics.xml",
+				"bar.ear", "bar.earbundle", "ear-app-config.xml"));
+		
+		assertThat(
+			readBundleFile(bundleRoot, "bar.earbundle"),
+			isIdenticalTo(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<earbundle appConfigFile=\"ear-app-config.xml\" jvmserver=\"banana\" symbolicname=\"bar\"/>"
+			)
+		);
+	}
+
+	@Test
+	public void publishEarWithAddCICSAllAuthFalse() throws Exception {
+		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3);
+		bundlePublisher.addResource(new EarBundlePart("bar", "banana", false, null, ear));
+		
+		bundlePublisher.publishResources();
+		bundlePublisher.publishDynamicResources();
+		
+		assertThat(
+			readBundleFile(bundleRoot, "bar.earbundle"),
+			isIdenticalTo(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<earbundle addCICSAllAuth=\"false\" jvmserver=\"banana\" symbolicname=\"bar\"/>"
+			)
+		);
+	}
+
+	@Test
+	public void publishEarWithBothAppConfigFileAndAddCICSAllAuthFalse() throws Exception {
+		File appConfigFile = tf.newFile("ear-app-config.xml");
+		FileUtils.write(appConfigFile, "<server></server>", StandardCharsets.UTF_8);
+		
+		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3);
+		bundlePublisher.addResource(new EarBundlePart("bar", "banana", false, appConfigFile, ear));
+		
+		bundlePublisher.publishResources();
+		bundlePublisher.publishDynamicResources();
+		
+		assertThat(
+			readBundleFile(bundleRoot, "bar.earbundle"),
+			isIdenticalTo(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<earbundle addCICSAllAuth=\"false\" appConfigFile=\"ear-app-config.xml\" jvmserver=\"banana\" symbolicname=\"bar\"/>"
+			)
+		);
+	}
+
+	@Test
+	public void publishWarWithAppConfigFile() throws Exception {
+		File war = tf.newFile("my.war");
+		FileUtils.write(war, "war contents", StandardCharsets.UTF_8);
+		File appConfigFile = tf.newFile("war-app-config.xml");
+		FileUtils.write(appConfigFile, "<server></server>", StandardCharsets.UTF_8);
+		
+		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3);
+		bundlePublisher.addResource(new WarBundlePart("webapp", "banana", true, appConfigFile, war));
+		
+		bundlePublisher.publishResources();
+		bundlePublisher.publishDynamicResources();
+		
+		List<String> paths = Files
+			.walk(bundleRoot)
+			.sorted()
+			.map(bundleRoot::relativize)
+			.map(Path::toString)
+			.collect(Collectors.toList());
+		
+		assertThat(paths, containsInAnyOrder("", "META-INF", "META-INF" + File.separator + "cics.xml",
+				"webapp.war", "webapp.warbundle", "war-app-config.xml"));
+		
+		assertThat(
+			readBundleFile(bundleRoot, "webapp.warbundle"),
+			isIdenticalTo(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<warbundle appConfigFile=\"war-app-config.xml\" jvmserver=\"banana\" symbolicname=\"webapp\"/>"
+			)
+		);
+	}
+
+	@Test
+	public void publishWarWithAddCICSAllAuthFalse() throws Exception {
+		File war = tf.newFile("my.war");
+		FileUtils.write(war, "war contents", StandardCharsets.UTF_8);
+		
+		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3);
+		bundlePublisher.addResource(new WarBundlePart("webapp", "banana", false, null, war));
+		
+		bundlePublisher.publishResources();
+		bundlePublisher.publishDynamicResources();
+		
+		assertThat(
+			readBundleFile(bundleRoot, "webapp.warbundle"),
+			isIdenticalTo(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<warbundle addCICSAllAuth=\"false\" jvmserver=\"banana\" symbolicname=\"webapp\"/>"
+			)
+		);
+	}
+
+	@Test
+	public void publishWarWithBothAppConfigFileAndAddCICSAllAuthFalse() throws Exception {
+		File war = tf.newFile("my.war");
+		FileUtils.write(war, "war contents", StandardCharsets.UTF_8);
+		File appConfigFile = tf.newFile("war-app-config.xml");
+		FileUtils.write(appConfigFile, "<server></server>", StandardCharsets.UTF_8);
+		
+		BundlePublisher bundlePublisher = new BundlePublisher(bundleRoot, "foo", 1, 2, 3);
+		bundlePublisher.addResource(new WarBundlePart("webapp", "banana", false, appConfigFile, war));
+		
+		bundlePublisher.publishResources();
+		bundlePublisher.publishDynamicResources();
+		
+		assertThat(
+			readBundleFile(bundleRoot, "webapp.warbundle"),
+			isIdenticalTo(
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+				"<warbundle addCICSAllAuth=\"false\" appConfigFile=\"war-app-config.xml\" jvmserver=\"banana\" symbolicname=\"webapp\"/>"
 			)
 		);
 	}


### PR DESCRIPTION
Added support for the two new CICS Liberty bundlepart configuration options for WAR and EAR bundleparts:

* `appConfigFile`
* `addCICSAllAuth`

# Description of changes

* `EarBundlePart` - new constructor: `EarBundlePart(String, String, boolean, File , File)` to accept the new options.
* `WarBundlePart` - new constructor: `WarBundlePart(String, String, boolean, File , File)` to accept the new options.
* `AbstractLibertyApplicationBundlePart` - new abstract class to abstract new Liberty bundlepart options.
* JavaDoc improvements where relevant
* Updated tests to work on all systems.
* Added new tests for the above changes.