### PR TITLE
github action workflows around releasing

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,73 @@
+name: Post Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - pom.xml
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  post-release:
+    name: Create GitHub Release and open next-dev PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read current version
+        id: version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "current=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Exit if this is a SNAPSHOT commit
+        if: contains(steps.version.outputs.current, '-SNAPSHOT')
+        run: echo "SNAPSHOT version — nothing to do." && exit 0
+
+      - name: Create GitHub Release
+        if: "!contains(steps.version.outputs.current, '-SNAPSHOT')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.current }}" \
+            --title "v${{ steps.version.outputs.current }}" \
+            --generate-notes
+
+      - name: Compute next SNAPSHOT version
+        if: "!contains(steps.version.outputs.current, '-SNAPSHOT')"
+        id: next
+        run: |
+          VERSION=${{ steps.version.outputs.current }}
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          echo "version=${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT" >> "$GITHUB_OUTPUT"
+
+      - name: Update pom.xml
+        if: "!contains(steps.version.outputs.current, '-SNAPSHOT')"
+        run: mvn -B versions:set -DnewVersion=${{ steps.next.outputs.version }} -DgenerateBackupPoms=false
+
+      - name: Open next-dev PR
+        if: "!contains(steps.version.outputs.current, '-SNAPSHOT')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="develop/${{ steps.next.outputs.version }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add pom.xml
+          git commit -m "develop ${{ steps.next.outputs.version }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Develop ${{ steps.next.outputs.version }}" \
+            --body  "Bumps version to \`${{ steps.next.outputs.version }}\` following the \`${{ steps.version.outputs.current }}\` release." \
+            --base  main \
+            --head  "$BRANCH"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,51 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    name: Strip -SNAPSHOT and open PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read current version
+        id: version
+        run: |
+          SNAPSHOT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          RELEASE_VERSION=${SNAPSHOT_VERSION%-SNAPSHOT}
+          echo "snapshot=$SNAPSHOT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release=$RELEASE_VERSION"   >> "$GITHUB_OUTPUT"
+
+      - name: Fail if not a SNAPSHOT version
+        if: steps.version.outputs.snapshot == steps.version.outputs.release
+        run: |
+          echo "Current version is not a SNAPSHOT: ${{ steps.version.outputs.snapshot }}"
+          exit 1
+
+      - name: Update pom.xml
+        run: mvn -B versions:set -DnewVersion=${{ steps.version.outputs.release }} -DgenerateBackupPoms=false
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="release/${{ steps.version.outputs.release }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add pom.xml
+          git commit -m "ship ${{ steps.version.outputs.release }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Release ${{ steps.version.outputs.release }}" \
+            --body  "Strips \`-SNAPSHOT\` from \`pom.xml\` to release \`${{ steps.version.outputs.release }}\`. Merging this will trigger the deploy to OSSRH." \
+            --base  main \
+            --head  "$BRANCH"


### PR DESCRIPTION
Create workflows around releasing.

1. prepare release - triggered manually in the actions UI
2. post release - adds SNAPSHOT back on automatically after a release occurs

I have tried some of the commands but have not yet been able to test them as a whole. I think it looks plausible and because it's essentially just creating a PR (and a release which could be deleted, for the post-release) it's fairly low risk.